### PR TITLE
pre-commit command not found

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ help:
 	@python -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
 
 init: ## Initializes the development environment
-	conda env create --force .
+	conda env update . || conda env create .
 	conda run -n {{ cookiecutter.project_repo }}-dev
 
 clean: clean-build clean-pyc clean-test ## remove all build, test, coverage and Python artifacts

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ help:
 
 init: ## Initializes the development environment
 	conda env create --force .
-	pre-commit install
+	conda run -n {{ cookiecutter.project_repo }}-dev
 
 clean: clean-build clean-pyc clean-test ## remove all build, test, coverage and Python artifacts
 


### PR DESCRIPTION
On a new project, `make init` fails with the error message:

```
pre-commit install
make: pre-commit: Command not found
make: *** [init] Error 127
```

https://github.com/sodre/ght-pypackage/blob/1325855217641767077b7df6d5232c52f3f81ea6/Makefile#L29-L31